### PR TITLE
chore(docker): Configure Redis kernel parameters for production

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,9 @@ services:
       timeout: 10s
       retries: 3
     restart: unless-stopped
+    sysctls:
+      - net.core.somaxconn=511
+      - vm.overcommit_memory=1
 
   backend:
     build:


### PR DESCRIPTION
- Add net.core.somaxconn=511 sysctl to increase connection backlog limit
- Add vm.overcommit_memory=1 sysctl to allow memory overcommitment
- Improve Redis stability and performance under high connection load