### PR TITLE
chore(docker): Remove Redis kernel parameter configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,9 +28,6 @@ services:
       timeout: 10s
       retries: 3
     restart: unless-stopped
-    sysctls:
-      - net.core.somaxconn=511
-      - vm.overcommit_memory=1
 
   backend:
     build:


### PR DESCRIPTION
- Remove sysctls configuration from Redis service in docker-compose.yml
- Delete net.core.somaxconn and vm.overcommit_memory settings
- Simplify Redis service configuration by relying on system defaults
- These parameters are better managed at the host level for production environments